### PR TITLE
Add helper for cloning zaidblooders repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ It means that you can:
 
 [Read the official "Getting Started" guide](https://api-platform.com/docs/distribution).
 
+## Cloning the `Satrnasb/zaidblooders` repository
+
+Use the helper script to clone the repository with the [GitHub CLI](https://cli.github.com/):
+
+```bash
+./scripts/clone-zaidblooders.sh [target-directory]
+```
+
+The script checks that `gh` is installed, avoids overwriting existing paths, and defaults to cloning into a `zaidblooders` folder when no target directory is provided.
+
 ## Credits
 
 Created by [Kévin Dunglas](https://dunglas.fr). Commercial support available at [Les-Tilleuls.coop](https://les-tilleuls.coop).

--- a/scripts/clone-zaidblooders.sh
+++ b/scripts/clone-zaidblooders.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_DIR=${1:-zaidblooders}
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI (gh) is required to clone Satrnasb/zaidblooders." >&2
+  echo "Install gh from https://cli.github.com/ before running this script." >&2
+  exit 1
+fi
+
+if [ -e "$TARGET_DIR" ]; then
+  echo "The target path '$TARGET_DIR' already exists. Choose another location or remove the existing path before cloning." >&2
+  exit 1
+fi
+
+echo "Cloning Satrnasb/zaidblooders into '$TARGET_DIR'..."
+gh repo clone Satrnasb/zaidblooders "$TARGET_DIR"


### PR DESCRIPTION
## Summary
- add a helper script to clone Satrnasb/zaidblooders using the GitHub CLI with basic safety checks
- document how to run the helper script from the README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f3835aa5c8328a2152facc1b9b4c3)